### PR TITLE
chore: Use ramdisk and small resource class for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
   lint-test:
     docker:
       - image: cimg/node:lts
+    resource_class: small
+    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-cache_key: &cache_key eslint-config-20201111-{{ checksum "yarn.lock" }}
+cache_key: &cache_key eslint-config-20201125-{{ checksum "yarn.lock" }}
 
 jobs:
   lint-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
   lint-test:
     docker:
       - image: cimg/node:lts
-    resource_class: small
     working_directory: /mnt/ramdisk
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
   lint-test:
     docker:
       - image: cimg/node:lts
+    resource_class: small
     working_directory: /mnt/ramdisk
     steps:
       - checkout


### PR DESCRIPTION
Use ramdisk since it makes resource `node_modules` from cache significantly faster.